### PR TITLE
gh::get_tag allows retrieving the actual commit pointed by an annotated tag

### DIFF
--- a/gh/refs.hxx
+++ b/gh/refs.hxx
@@ -27,10 +27,30 @@ namespace gh::git_data {
   };
 
   using refs = std::vector<ref_t>;
+
+  struct verification_t {
+    bool verified;
+    std::string reason;
+    std::optional<std::string> signature;
+    std::optional<std::string> payload;
+  };
+
+  //! |brief Object type "tag" on github is used only for tags with annotations
+  struct tag_t {
+    std::string sha;
+    std::string tag;
+    std::string message;
+    std::string url;
+    object_t object;
+    std::optional<verification_t> verification;
+  };
+
 }
 
 BOOST_FUSION_ADAPT_STRUCT(gh::git_data::object_t, type, sha, url);
 BOOST_FUSION_ADAPT_STRUCT(gh::git_data::ref_t, ref, url, object);
+BOOST_FUSION_ADAPT_STRUCT(gh::git_data::verification_t, verified, reason, signature, payload);
+BOOST_FUSION_ADAPT_STRUCT(gh::git_data::tag_t, sha, tag, message, url, object, verification);
 
 
 namespace gh {
@@ -127,6 +147,43 @@ namespace gh {
     auto response_handler = [&](auto&& resp) {
       if ( (!resp.error) && (resp.status_code == 200) ) {
         result_handler(pre::json::from_json<git_data::ref_t>(resp.text));
+      } else {
+        throw std::runtime_error( "err : "s + std::string(resp.error) + "status: "s 
+            + std::to_string(resp.status_code) + " accessing : "s + url );
+      }
+    };
+
+    if (auth) {
+      GET(url, Authentication{auth->user, auth->pass},
+        on_response = response_handler);
+    } else {
+      GET(url, on_response = response_handler);
+    }
+
+  }
+
+
+  /**
+   * \brief get an annotated tag details, useful to know which commit the annotated tag refers too.
+   * \param auth credentials
+   * \param owner
+   * \param repository
+   * \param annotated_tag_obj_sha The sha of the annotation object that the tags points to. This is the object.sha from an object returned by get_refs, when object.type is "tag".
+   * \param result_handler taking a single git::data::tag_t
+   */
+  inline void get_tag(std::string owner, std::string repository,
+    const std::string& annotated_tag_obj_sha,
+    std::function<void(git_data::tag_t&&)>&& result_handler,
+    std::optional<auth> auth = std::nullopt,
+    const std::string& api_endpoint = "https://api.github.com"s ) {
+  
+    using namespace xxhr;
+    auto url = api_endpoint + "/repos/"s + owner + "/" + repository
+      + "/git/tags/" + annotated_tag_obj_sha;
+
+    auto response_handler = [&](auto&& resp) {
+      if ( (!resp.error) && (resp.status_code == 200) ) {
+        result_handler(pre::json::from_json<git_data::tag_t>(resp.text));
       } else {
         throw std::runtime_error( "err : "s + std::string(resp.error) + "status: "s 
             + std::to_string(resp.status_code) + " accessing : "s + url );

--- a/test/gh-refs.cpp
+++ b/test/gh-refs.cpp
@@ -34,5 +34,9 @@ int main(int argc, char** argv) {
     std::cout << "Successfully retrieved " << refs.size() << " refs from github.com/grpc/grpc with AUTHENTICATION - which is a PASS" << std::endl;
   }, auth);
 
+  gh::get_tag("nlohmann", "json", "0ca0fe433eb70cea0d5761079c0c5b47b736565b", [](gh::git_data::tag_t&& annotated) {
+    std::cout << "Successfully retrieved 0ca0fe433eb70cea0d5761079c0c5b47b736565b: " << annotated.tag << " pointing to commit " << annotated.object.sha << std::endl;
+  }, auth);
+
   return 0;
 }


### PR DESCRIPTION
This PR adds the capability to retrieve the commit pointed by an actual tag.

The issue is when someone does a get_refs for **tags** on Github , for example : https://api.github.com/repos/nlohmann/json/git/refs/tags , you get the list of tags, but tags that have an annotation point to an object in the DAG containing their annotation : 

```json
[
...

  {
    "ref": "refs/tags/v3.10.0",
    "node_id": "MDM6UmVmMTExNzE1NDg6cmVmcy90YWdzL3YzLjEwLjA=",
    "url": "https://api.github.com/repos/nlohmann/json/git/refs/tags/v3.10.0",
    "object": {
      "sha": "f42a74b8f53cc308647123d49d33d1c8122e3f42",
      "type": "commit",
      "url": "https://api.github.com/repos/nlohmann/json/git/commits/f42a74b8f53cc308647123d49d33d1c8122e3f42"
    }
  },


...

  {
    "ref": "refs/tags/3.6.1",
    "node_id": "MDM6UmVmMTExNzE1NDg6cmVmcy90YWdzLzMuNi4x",
    "url": "https://api.github.com/repos/nlohmann/json/git/refs/tags/3.6.1",
    "object": {
      "sha": "7b7b15407cb7d59488a6035dddc04e204830d1e5",
      "type": "tag",
      "url": "https://api.github.com/repos/nlohmann/json/git/tags/7b7b15407cb7d59488a6035dddc04e204830d1e5"
    }
  }
]
```

This allows requesting details about **7b7b15407cb7d59488a6035dddc04e204830d1e5** to get the actual commit SHA pointed to by the tag.

Relates to nxxm/nxxm-src#840

