### PR TITLE
Pagination support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     env:
       GH_USER: nxxmgh
       GH_PASS: ${{ secrets.USER_PAT_NXXMGH_TOKEN_FOR_GH }}
-      GH_RELEASE_TEST_REPO_OWNER: tipibuild
-      GH_RELEASE_TEST_REPO_NAME: test-gh-client-release
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: tipibuild/tipi-ubuntu
-      options: --user 1000:1000
+      options: --user root
     env:
       GH_USER: nxxmgh
       GH_PASS: ${{ secrets.USER_PAT_NXXMGH_TOKEN_FOR_GH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ jobs:
   build: 
     name: build-linux
     runs-on: ubuntu-latest
-    container: tipibuild/tipi-ubuntu
+    container: 
+      image: tipibuild/tipi-ubuntu
+      options: --user 1000:1000
     env:
       GH_USER: nxxmgh
       GH_PASS: ${{ secrets.USER_PAT_NXXMGH_TOKEN_FOR_GH }}

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,5 +1,132 @@
 {
-   "nxxm/xxhr" : { "@" : "feature/move-to-native-tipi-deps" }
-   , "cpp-pre/json" : { "@" : "feature/move-to-native-tipi-deps" }
-   , "cpp-pre/type_traits": {}
+   "cpp-pre/json": {
+      "@": "feature/move-to-native-tipi-deps",
+      "requires": {
+         "boostorg/boost": {
+            "@": "boost-1.80.0",
+            "opts": "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)",
+            "packages": [
+               "boost_system",
+               "boost_filesystem",
+               "boost_uuid"
+            ],
+            "targets": [
+               "Boost::system",
+               "Boost::filesystem",
+               "Boost::uuid"
+            ],
+            "u": true
+         },
+         "nlohmann/json": {
+            "@": "v3.11.2",
+            "u": false,
+            "x": [
+               "benchmarks",
+               "/tests",
+               "/docs",
+               "/tools"
+            ]
+         }
+      },
+      "u": false
+   },
+   "cpp-pre/type_traits": {
+      "@": "v2.0.0",
+      "u": false,
+      "x": [
+         "/test"
+      ]
+   },
+   "nxxm/xxhr": {
+      "@": ":faa17ac3547ad194d916ea69ac3fd479202629da",
+      "requires": {
+         "aantron/better-enums": {
+            "@": "0.11.1",
+            "u": false,
+            "x": [
+               "/example",
+               "/script",
+               "/doc",
+               "/test"
+            ]
+         },
+         "boostorg/boost": {
+            "@": "boost-1.80.0",
+            "opts": "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)",
+            "packages": [
+               "boost_system",
+               "boost_filesystem",
+               "boost_uuid"
+            ],
+            "targets": [
+               "Boost::system",
+               "Boost::filesystem",
+               "Boost::uuid"
+            ],
+            "u": true
+         },
+         "nxxm/curl": {
+            "@": ":eee4ae62ee24aec9c7f8948fd8670a5e80c2cf83",
+            "opts": "set(BUILD_CURL_TESTS OFF) \nset(BUILD_CURL_EXE ON) \nset(CMAKE_USE_OPENSSL ON) \nset(CMAKE_USE_LIBSSH2 OFF) \nset(BUILD_TESTING OFF)",
+            "packages": [
+               "CURL"
+            ],
+            "requires": {
+               "hunter-packages/c-ares": {
+                  "@": "v1.14.0-p0",
+                  "packages": [
+                     "c-ares"
+                  ],
+                  "targets": [
+                     "c-ares::cares"
+                  ],
+                  "u": true
+               },
+               "hunter-packages/zlib": {
+                  "@": "v1.2.11-p1",
+                  "packages": [
+                     "ZLIB"
+                  ],
+                  "targets": [
+                     "ZLIB::zlib"
+                  ],
+                  "u": true
+               },
+               "nxxm/boringssl": {
+                  "@": ":358175c062c3a3964d4734df4b122e6af851def0",
+                  "u": true,
+                  "packages": [
+                     "OpenSSL",
+                     "BoringSSL"
+                  ],
+                  "targets": [
+                     "OpenSSL::SSL",
+                     "OpenSSL::Crypto",
+                     "BoringSSL::decrepit"
+                  ],
+                  "find_mode": " "
+               }
+            },
+            "targets": [
+               "CURL::libcurl"
+            ],
+            "u": true
+         }
+      }
+   },
+   "boostorg/boost": {
+      "@": "boost-1.80.0",
+      "opts": "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)",
+      "packages": [
+         "boost_system",
+         "boost_filesystem",
+         "boost_uuid"
+      ],
+      "targets": [
+         "Boost::system",
+         "Boost::filesystem",
+         "Boost::uuid"
+      ],
+      "u": true
+   }
 }

--- a/gh/branches.hxx
+++ b/gh/branches.hxx
@@ -97,8 +97,7 @@ namespace gh {
           result_handler({all_branches.begin(), all_branches.end()});
         }
       } else {
-        std::string err_msg = resp.error;
-        throw std::runtime_error(resp.url + " failed with error: " + err_msg);
+        throw std::runtime_error(resp.url + " failed with error: " + std::string(resp.error));
       }
     };
 

--- a/gh/branches.hxx
+++ b/gh/branches.hxx
@@ -44,6 +44,8 @@ BOOST_FUSION_ADAPT_STRUCT(gh::repos::branch_t, name, commit, protection_url, is_
 
 namespace gh {
 
+  using namespace std::string_literals;
+
   /**
    * \brief list github branches, passing them to the result_handler as std::vector<branch_t>.
    *        See https://developer.github.com/v3/repos/branches/#list-branches 
@@ -54,7 +56,8 @@ namespace gh {
    * \param result_handler Callable with signature : `func(std::vector<branch_t>)`
    */
   inline void list_branches(std::string owner, std::string repos, std::function<void(repos::branches&&)>&& result_handler,
-    std::optional<auth> auth = std::nullopt) {
+    std::optional<auth> auth = std::nullopt,
+    const std::string& api_endpoint = "https://api.github.com"s) {
 
     using namespace xxhr;
     std::function<void(xxhr::Response&&)> response_handler;
@@ -94,14 +97,14 @@ namespace gh {
           do_request(next_page.value());
         }
         else {
-          result_handler({all_branches.begin(), all_branches.end()});
+          result_handler(std::move(all_branches));
         }
       } else {
         throw std::runtime_error(resp.url + " failed with error: " + std::string(resp.error) + " - " + resp.text);
       }
     };
 
-    auto url = "https://api.github.com/repos/"s + owner + "/" + repos + "/branches?" + gh::detail::pagination::get_per_page_query_string();
+    auto url = api_endpoint + "/repos/" + owner + "/" + repos + "/branches?" + gh::detail::pagination::get_per_page_query_string();
     do_request(url);
   }
 }

--- a/gh/branches.hxx
+++ b/gh/branches.hxx
@@ -97,7 +97,7 @@ namespace gh {
           result_handler({all_branches.begin(), all_branches.end()});
         }
       } else {
-        throw std::runtime_error(resp.url + " failed with error: " + std::string(resp.error));
+        throw std::runtime_error(resp.url + " failed with error: " + std::string(resp.error) + " - " + resp.text);
       }
     };
 

--- a/gh/issues.hxx
+++ b/gh/issues.hxx
@@ -148,7 +148,7 @@ namespace gh {
           do_request(next_page.value());
         }
         else {
-          result_handler({ all_issues.begin(), all_issues.end()});
+          result_handler(std::move(all_issues));
         }
       } else {
         throw std::runtime_error( "err : "s + std::string(resp.error) + "status: "s 

--- a/gh/issues.hxx
+++ b/gh/issues.hxx
@@ -12,6 +12,7 @@
 
 #include <gh/owner.hxx>
 #include <gh/auth.hxx>
+#include <gh/pagination.hxx>
 
 namespace gh::repos {
 
@@ -67,7 +68,7 @@ namespace gh::repos {
     uint64_t number;
     std::string state;
     std::string title;
-    std::string body;
+    std::optional<std::string> body;
     owner_t user;
 
     std::vector<label_t> labels;
@@ -123,31 +124,40 @@ namespace gh {
     const std::string& api_endpoint = "https://api.github.com"s ) {
 
     using namespace xxhr;
-    auto url = api_endpoint + "/repos/"s + owner + "/" + repository + "/issues";
+    std::function<void(xxhr::Response&&)> response_handler;
+    repos::issues all_issues;
 
-    auto response_handler = [&](auto&& resp) {
+    auto do_request = [&](std::string url) {
+      if (auth) {
+        GET(url,
+          Authentication{auth->user, auth->pass},
+          on_response = response_handler);
+      } else {
+        GET(url, on_response = response_handler);
+      }
+    };   
+
+    response_handler = [&](auto&& resp) {
       if ( (!resp.error) && (resp.status_code == 200) ) {
-        result_handler(pre::json::from_json<repos::issues>(resp.text));
+        auto page = pre::json::from_json<repos::issues>(resp.text);
+        all_issues.insert(all_issues.end(), page.begin(), page.end());
+
+        auto next_page = gh::detail::pagination::get_next_page_url(resp);
+        
+        if(next_page) {
+          do_request(next_page.value());
+        }
+        else {
+          result_handler({ all_issues.begin(), all_issues.end()});
+        }
       } else {
         throw std::runtime_error( "err : "s + std::string(resp.error) + "status: "s 
-            + std::to_string(resp.status_code) + " accessing : "s + url );
+            + std::to_string(resp.status_code) + " accessing : "s + resp.url );
       }
     };
 
-
-    if (auth) {
-      GET(url,
-        Parameters{{"state", state}},
-        Authentication{auth->user, auth->pass},
-        on_response = response_handler);
-    } else {
-      GET(url,
-        Parameters{{"state", state}},
-        on_response = response_handler);
-    }
-
-
-
+    auto url = api_endpoint + "/repos/"s + owner + "/" + repository + "/issues?state=" + state + "&" + gh::detail::pagination::get_per_page_query_string();
+    do_request(url);
   }
 
   inline void get_issue(std::string owner, std::string repository, uint64_t issue_number,

--- a/gh/pagination.hxx
+++ b/gh/pagination.hxx
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <xxhr/xxhr.hpp>
+#include <xxhr/util.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
+
+namespace gh::detail::pagination {
+
+    const size_t MAX_PAGE_SIZE = 100;
+    const size_t MIN_PAGE_SIZE = 5;
+    const size_t DEFAULT_PAGE_SIZE = 30;
+
+    const std::string PAGE_LINK_FIRST = "first";
+    const std::string PAGE_LINK_LAST = "last";
+    const std::string PAGE_LINK_NEXT = "next";
+    const std::string PAGE_LINK_PREVIOUS = "prev";
+
+    const std::string HEADER_NAME_PAGE_LINKS = "link";
+
+    inline bool has_gh_pagination_links(const xxhr::Response &resp) {
+        return resp.header.find(HEADER_NAME_PAGE_LINKS) != resp.header.end();
+    }
+    
+    inline std::map<std::string, std::string> parse_gh_pagination_header(std::string header_value) {
+        // as per doc https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28, the header comes as:
+        // link: <https://api.github.com/repositories/1300192/issues?page=2>; rel="prev", <https://api.github.com/repositories/1300192/issues?page=4>; rel="next", <https://api.github.com/repositories/1300192/issues?page=515>; rel="last", <https://api.github.com/repositories/1300192/issues?page=1>; rel="first"
+        using namespace std::string_literals;
+    
+        std::map<std::string, std::string> result;
+
+        std::vector<std::string> link_parts;
+        boost::split(link_parts, header_value, boost::is_any_of(","));
+
+        for(auto lp : link_parts) {
+
+            size_t pos_semicolon = lp.find(';', 0);
+
+            std::string url_fragment = lp.substr(0, pos_semicolon); // should look like ' <https://api.github.com/repositories/1300192/issues?page=2>'
+            boost::trim_all_if(url_fragment, boost::is_any_of("<> "));
+
+
+            std::string rel_fragment = lp.substr(pos_semicolon + 1 /* skip the semicolon */); 
+            boost::trim_all(rel_fragment);  // should now look like 'rel="page-link-name"' 
+
+            static const std::string rel_prefix = "rel=";
+            if(boost::starts_with(rel_fragment, rel_prefix)) {
+                rel_fragment = rel_fragment.substr(rel_prefix.length());
+                boost::trim_if(rel_fragment, boost::is_any_of("\""));
+            }
+            else {
+                throw std::runtime_error("Cannot parse malformed GH pagination header: link: "s + header_value);
+            }
+
+            result.insert({ rel_fragment, url_fragment });
+        }
+
+        return result;
+    }
+
+
+    inline std::optional<std::string> get_next_page_url(const xxhr::Response &resp) {
+
+        if(has_gh_pagination_links(resp)) {
+            auto links = parse_gh_pagination_header(resp.header.at(HEADER_NAME_PAGE_LINKS));
+            auto next_page_it = links.find(PAGE_LINK_NEXT);
+            if(next_page_it != links.end()) {
+                return next_page_it->second;              
+            }
+        }
+
+        return std::nullopt;
+    }
+  
+}

--- a/gh/pagination.hxx
+++ b/gh/pagination.hxx
@@ -73,9 +73,11 @@ namespace gh::detail::pagination {
         return std::nullopt;
     }
 
+    const std::string QUERY_STRING_PER_PAGE_KEY = "per_page";
+
     //! \brief get the query string fragment for paginated urls
     inline std::string get_per_page_query_string(size_t per_page = MAX_PAGE_SIZE) {
-        return "per_page="s + std::to_string(per_page);
+        return QUERY_STRING_PER_PAGE_KEY + "="s + std::to_string(per_page);
     }
   
 }

--- a/gh/pagination.hxx
+++ b/gh/pagination.hxx
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string/split.hpp>
 
 namespace gh::detail::pagination {
+    using namespace std::string_literals;
 
     const size_t MAX_PAGE_SIZE = 100;
     const size_t MIN_PAGE_SIZE = 5;
@@ -26,9 +27,7 @@ namespace gh::detail::pagination {
     
     inline std::map<std::string, std::string> parse_gh_pagination_header(std::string header_value) {
         // as per doc https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28, the header comes as:
-        // link: <https://api.github.com/repositories/1300192/issues?page=2>; rel="prev", <https://api.github.com/repositories/1300192/issues?page=4>; rel="next", <https://api.github.com/repositories/1300192/issues?page=515>; rel="last", <https://api.github.com/repositories/1300192/issues?page=1>; rel="first"
-        using namespace std::string_literals;
-    
+        // link: <https://api.github.com/repositories/1300192/issues?page=2>; rel="prev", <https://api.github.com/repositories/1300192/issues?page=4>; rel="next", <https://api.github.com/repositories/1300192/issues?page=515>; rel="last", <https://api.github.com/repositories/1300192/issues?page=1>; rel="first"    
         std::map<std::string, std::string> result;
 
         std::vector<std::string> link_parts;
@@ -60,7 +59,7 @@ namespace gh::detail::pagination {
         return result;
     }
 
-
+    //! \brief returns the next page URL or nullopt given a xxhr Response
     inline std::optional<std::string> get_next_page_url(const xxhr::Response &resp) {
 
         if(has_gh_pagination_links(resp)) {
@@ -72,6 +71,11 @@ namespace gh::detail::pagination {
         }
 
         return std::nullopt;
+    }
+
+    //! \brief get the query string fragment for paginated urls
+    inline std::string get_per_page_query_string(size_t per_page = MAX_PAGE_SIZE) {
+        return "per_page="s + std::to_string(per_page);
     }
   
 }

--- a/gh/refs.hxx
+++ b/gh/refs.hxx
@@ -93,7 +93,7 @@ namespace gh {
     auto response_handler = [&](auto&& resp) {
       // sometimes, on very large repositories like GRPC, github.com seems to struggle,
       // but it's able to respond the query in two slices by looking up refs and then heads separately
-      if(resp.status_code == 502 && filter == filter_refs::ALL) {
+      if((resp.status_code == 502 || resp.status_code == 504) && filter == filter_refs::ALL) {
 
         git_data::refs manual_aggregation{};
 
@@ -113,7 +113,7 @@ namespace gh {
         result_handler(pre::json::from_json<git_data::refs>(resp.text));
       } else {
         throw std::runtime_error( "err : "s + std::string(resp.error) + "status: "s 
-            + std::to_string(resp.status_code) + " accessing : "s + url );
+            + std::to_string(resp.status_code) + " accessing : "s + url + " --- " + resp.text);
       }
     };
 

--- a/gh/releases.hxx
+++ b/gh/releases.hxx
@@ -454,9 +454,8 @@ namespace gh {
           do_request(next_page.value());
         }
         else {
-          result_handler({all_releases.begin(), all_releases.end()});
+          result_handler(std::move(all_releases));
         }
-
         
       } else {
         throw std::runtime_error( "err : "s + std::string(resp.error) + "status: "s 

--- a/gh/search.hxx
+++ b/gh/search.hxx
@@ -142,7 +142,7 @@ namespace gh {
           do_request(next_page.value(), xxhr::Parameters{});
         }
         else {
-          result_handler({all_results.begin(), all_results.end()});
+          result_handler(std::move(all_results));
         }
       } else {
         throw std::runtime_error(resp.url + " failed with error: " + std::string(resp.error));

--- a/test/gh-branches.cpp
+++ b/test/gh-branches.cpp
@@ -18,13 +18,14 @@ int main(int argc, char** argv) {
 
   gh::list_branches("llvm", "llvm-project", [](gh::repos::branches&& branches) {
     assertm(branches.size() > 100, "We expect this to query multiple pages");
-  }, auth);
 
-  // a repo with branch protections
-  gh::list_branches("tipibuild", "test-gh-client-release", [&](gh::repos::branches&& branches) {
-    
-    auto findit = std::find_if(branches.begin(), branches.end(), [](gh::repos::branch_t& b) { return b.is_protected; });
-    
+    // note on this:
+    // the reason this aspect is tested is that the DTO sent by github does contain a "protected" property which gh:: remaps to "is_protected"
+    // to circumnvent the use of the reserved C++ keyword in a struct/class.
+    // 
+    // We are expecting the llvm-project to have a few protected branches (e.g. at least main seems to be at
+    // time of writing). 
+    auto findit = std::find_if(branches.begin(), branches.end(), [](gh::repos::branch_t& b) { return b.is_protected; });    
     assertm(findit != branches.end(), "No protected branch found in repo / was expected");
   }, auth);
 

--- a/test/gh-branches.cpp
+++ b/test/gh-branches.cpp
@@ -10,18 +10,14 @@ int main(int argc, char** argv) {
     std::cout << pre::json::to_json(branches).dump(2) << std::endl;
   });
 
-
-  gh::auth auth{ 
-    std::getenv("GH_USER"),
-    std::getenv("GH_PASS")
-  };
+  auto auth = test_utils::get_auth();
 
   gh::list_branches("daminetreg", "xxhr", [](gh::repos::branches&& branches) {
     std::cout << pre::json::to_json(branches).dump(2) << std::endl;
   }, auth);
 
-  gh::list_branches("boostorg", "fusion", [](gh::repos::branches&& branches) {
-    std::cout << pre::json::to_json(branches).dump(2) << std::endl;
+  gh::list_branches("llvm", "llvm-project", [](gh::repos::branches&& branches) {
+    assertm(branches.size() > 100, "We expect this to query multiple pages");
   }, auth);
 
   // a repo with branch protections

--- a/test/gh-branches.cpp
+++ b/test/gh-branches.cpp
@@ -21,10 +21,7 @@ int main(int argc, char** argv) {
   }, auth);
 
   // a repo with branch protections
-  std::string repo_owner = std::getenv("GH_RELEASE_TEST_REPO_OWNER");
-  std::string repo_name = std::getenv("GH_RELEASE_TEST_REPO_NAME");
-
-  gh::list_branches(repo_owner, repo_name, [&](gh::repos::branches&& branches) {
+  gh::list_branches("tipibuild", "test-gh-client-release", [&](gh::repos::branches&& branches) {
     
     auto findit = std::find_if(branches.begin(), branches.end(), [](gh::repos::branch_t& b) { return b.is_protected; });
     

--- a/test/gh-issues.cpp
+++ b/test/gh-issues.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <pre/json/to_json.hpp>
+#include "utils.hpp"
 
 int main(int argc, char** argv) {
   gh::list_issues("nxxm", "nxxm", [](gh::repos::issues&& issues) {
@@ -15,20 +16,17 @@ int main(int argc, char** argv) {
     std::cout << pre::json::to_json(issue).dump(2) << std::endl;
   });
 
-  gh::auth auth{ 
-    std::getenv("GH_USER"),
-    std::getenv("GH_PASS")
-  };
+  auto auth = test_utils::get_auth();
+
 
   gh::get_issue("daminetreg", "lib-tftp-server", 1, [](gh::repos::issue_t&& issue) {
     std::cout << pre::json::to_json(issue).dump(2) << std::endl;
   }, auth);
 
-  gh::list_issues("cpp-pre", "json", [](gh::repos::issues&& issues) {
-    for (auto issue : issues) { 
-      std::cout << pre::json::to_json(issue).dump(2) << std::endl;
-    }
-  },"all", auth);
+  // making sure paging works
+  gh::list_issues("boostorg", "process", [](gh::repos::issues&& issues) {
+    assertm(issues.size() > 100, "Expecting at least 100 issues there (confirms we queried multiple pages)");
+  }, "all", auth);
 
   return 0;
 }

--- a/test/gh-pagination.cpp
+++ b/test/gh-pagination.cpp
@@ -1,0 +1,164 @@
+#include <boost/exception/diagnostic_information.hpp> 
+#include <gh/pagination.hxx>
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include "utils.hpp"
+
+int main(int argc, char** argv) {
+  using namespace std::string_literals;
+  size_t returnCode = 0;
+
+
+  std::string link_header_value = R"(<https://api.github.com/repositories/1300192/issues?page=2>; rel="prev", <https://api.github.com/repositories/1300192/issues?page=4>; rel="next", <https://api.github.com/repositories/1300192/issues?page=515>; rel="last", <https://api.github.com/repositories/1300192/issues?page=1>; rel="first")";
+  std::string link_header_value_no_next = R"(<https://api.github.com/repositories/1300192/issues?page=2>; rel="prev", <https://api.github.com/repositories/1300192/issues?page=515>; rel="last", <https://api.github.com/repositories/1300192/issues?page=1>; rel="first")";
+
+
+  auto test_chapter = [&](std::string title, auto&& fn) {
+    std::cout << "🧪 Test: " << title << std::flush;
+    bool success = true;
+    std::string exception_message = "";
+
+    try {
+      fn();
+    }
+    catch(...) {
+      success = false;
+      returnCode++;
+      exception_message = boost::current_exception_diagnostic_information();      
+    }
+
+    if(success) {
+      std::cout << " PASS ✅" << std::endl;
+    }
+    else {
+      std::cout << " FAIL 🟥\nException message: " << exception_message << std::endl;
+    }
+  };
+
+
+  test_chapter("Basics / gh::detail::pagination::parse_gh_pagination_header() ",
+    [&]() {     
+      auto val = gh::detail::pagination::parse_gh_pagination_header(link_header_value);
+
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_FIRST) != val.end(), "counldn't find link PAGE_LINK_FIRST");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_LAST) != val.end(), "counldn't find link PAGE_LINK_LAST");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_NEXT) != val.end(), "counldn't find link PAGE_LINK_NEXT");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_PREVIOUS) != val.end(), "counldn't find link PAGE_LINK_PREVIOUS");
+
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_FIRST)->second     == "https://api.github.com/repositories/1300192/issues?page=1",   "Wrong value");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_LAST)->second      == "https://api.github.com/repositories/1300192/issues?page=515", "Wrong value");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_NEXT)->second      == "https://api.github.com/repositories/1300192/issues?page=4",   "Wrong value");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_PREVIOUS)->second  == "https://api.github.com/repositories/1300192/issues?page=2",   "Wrong value");
+    }
+  );
+
+  // without next page:  
+  test_chapter("Basics / gh::detail::pagination::parse_gh_pagination_header() without next page",
+    [&]() {    
+      auto val = gh::detail::pagination::parse_gh_pagination_header(link_header_value_no_next);
+
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_NEXT) == val.end(), "counldn't find link PAGE_LINK_NEXT");
+
+      // everything else should be the same
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_FIRST) != val.end(), "counldn't find link PAGE_LINK_FIRST");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_LAST) != val.end(), "counldn't find link PAGE_LINK_LAST");    
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_PREVIOUS) != val.end(), "counldn't find link PAGE_LINK_PREVIOUS");
+
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_FIRST)->second     == "https://api.github.com/repositories/1300192/issues?page=1",   "Wrong value");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_LAST)->second      == "https://api.github.com/repositories/1300192/issues?page=515", "Wrong value");
+      assertm(val.find(gh::detail::pagination::PAGE_LINK_PREVIOUS)->second  == "https://api.github.com/repositories/1300192/issues?page=2",   "Wrong value");
+    }
+  );
+
+
+  // helpers for simulated XXHR responses
+  auto mk_error_OK = []() { return xxhr::Error{xxhr::ErrorCode::OK}; };
+
+  auto mk_headers_WITH_links = [&link_header_value, &link_header_value_no_next](bool with_next) {
+    return xxhr::Header{
+      { "Access-Control-Allow-Origin", "*" },
+      { "Connection", "Keep-Alive" },
+      { "Content-Encoding", "gzip" },
+      { "Content-Type", "text/html; charset=utf-8" },
+      { "Date", "Mon, 18 Jul 2016 16:06:00 GMT" },
+      { "link", (with_next ? link_header_value : link_header_value_no_next)  }
+    };
+  };
+
+  auto mk_headers_NO_links = []() {
+    return xxhr::Header{
+      { "Access-Control-Allow-Origin", "*" },
+      { "Connection", "Keep-Alive" },
+      { "Content-Encoding", "gzip" },
+      { "Content-Type", "text/html; charset=utf-8" },
+      { "Date", "Mon, 18 Jul 2016 16:06:00 GMT" }
+    };
+  };  
+
+  // tests with full links:
+  test_chapter("gh::detail::pagination::has_gh_pagination_links() with next page",
+    [&]() {    
+      xxhr::Response resp{ 
+        200, 
+        mk_error_OK(), 
+        "<h1>Text</h1>", 
+        mk_headers_WITH_links(true), 
+        "https://api.github.com/repositories/1300192/issues?page=3"s,
+        xxhr::Cookies{} 
+      };
+
+      assertm(gh::detail::pagination::has_gh_pagination_links(resp) == true, "Expected that the xxhr::Reponse has link: headers");
+
+      auto next_page = gh::detail::pagination::get_next_page_url(resp);
+      assertm(next_page.has_value(), "Should have had a next() page");
+      assertm(next_page.value() == "https://api.github.com/repositories/1300192/issues?page=4", "Unexpected value for next() page (should be page == 4)");
+    }
+  );
+
+  
+
+  // tests with links but no next page:
+  test_chapter("gh::detail::pagination::has_gh_pagination_links() WITOUT next page",
+    [&]() { 
+      xxhr::Response resp{ 
+        200, 
+        mk_error_OK(), 
+        "<h1>Text</h1>", 
+        mk_headers_WITH_links(false /* without NEXT page */), 
+        "https://api.github.com/repositories/1300192/issues?page=3"s, 
+        xxhr::Cookies{}
+      };
+
+      assertm(gh::detail::pagination::has_gh_pagination_links(resp) == true, "Expected that the xxhr::Reponse has link: headers");
+
+      auto next_page = gh::detail::pagination::get_next_page_url(resp);
+      assertm(next_page.has_value() == false, "Should NOT have had a next() page");
+    }
+  );
+
+
+  // tests nothing breaks WITHOUT links
+  test_chapter("gh::detail::pagination::has_gh_pagination_links() WITHOUT header links",
+    [&]() { 
+      xxhr::Response resp{
+        200,
+        mk_error_OK(),
+        "<h1>Text</h1>", 
+        mk_headers_NO_links(), 
+        "https://api.github.com/repositories/1300192/issues?page=3"s,
+        xxhr::Cookies{}
+      };
+
+      assertm(gh::detail::pagination::has_gh_pagination_links(resp) == false, "Expected that this xxhr::Reponse has NO link: headers"); 
+
+      auto next_page = gh::detail::pagination::get_next_page_url(resp);
+      assertm(next_page.has_value() == false, "Should NOT have had a next() page");
+    }
+  );
+
+
+  return returnCode;
+}

--- a/test/gh-refs.cpp
+++ b/test/gh-refs.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <pre/json/to_json.hpp>
+#include "utils.hpp"
 
 int main(int argc, char** argv) {
 
@@ -17,10 +18,7 @@ int main(int argc, char** argv) {
     std::cout << "Successfully retrieved " << refs.size() << " refs from github.com/grpc/grpc - which is a PASS" << std::endl;
   });
 
-  gh::auth auth{ 
-    std::getenv("GH_USER"),
-    std::getenv("GH_PASS")
-  };
+  auto auth = test_utils::get_auth();
 
   gh::get_refs("boostorg", "fusion", gh::filter_refs::TAGS, [](gh::git_data::refs&& tags) {
     std::cout << pre::json::to_json(tags).dump(2) << std::endl;

--- a/test/gh-releases.cpp
+++ b/test/gh-releases.cpp
@@ -91,8 +91,8 @@ int main(int argc, char** argv) {
 
   // testing the release creation
   {
-    std::string repo_owner = std::getenv("GH_RELEASE_TEST_REPO_OWNER");
-    std::string repo_name = std::getenv("GH_RELEASE_TEST_REPO_NAME");
+    std::string repo_owner = "tipibuild";
+    std::string repo_name = "test-gh-client-release";
 
     std::stringstream release_tag_ss; 
     release_tag_ss << "test-" << std::time(0);

--- a/test/gh-repos.cpp
+++ b/test/gh-repos.cpp
@@ -14,10 +14,7 @@ int main(int argc, char** argv) {
     std::cout << pre::json::to_json(r).dump(2) << std::endl;
   });
 
-  gh::auth auth{ 
-    std::getenv("GH_USER"),
-    std::getenv("GH_PASS")
-  };
+  auto auth = test_utils::get_auth();
 
   gh::repos_get("cpp-pre", "json", [](gh::repos::repository_t&& r) {
     std::cout << pre::json::to_json(r).dump(2) << std::endl;

--- a/test/gh-search.cpp
+++ b/test/gh-search.cpp
@@ -2,18 +2,17 @@
 
 #include <cstdlib>
 #include <pre/json/to_json.hpp>
+#include "utils.hpp"
 
 int main(int argc, char** argv) {
 
-  gh::auth auth{ 
-    std::getenv("GH_USER"),
-    std::getenv("GH_PASS")
-  };
+  auto auth = test_utils::get_auth();
 
   {
     std::cout << "pre ::: " << std::endl;
-    gh::query_code_search( "utils.hpp path:pre/bytes/",
+    gh::query_code_search( "helpers.hpp path:src/ language:CMake", // ~500 results
       [](auto&& possibles) {
+        assertm(possibles.size() > 100, "Should be more than 100 results (pagination test)");
         std::cout << pre::json::to_json(possibles).dump(2) << std::endl;
       },
       auth

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -1,4 +1,23 @@
 #pragma once
 #include <cassert>
+#include <gh/auth.hxx>
 
 #define assertm(exp, msg) assert(((void)msg, exp))
+
+
+namespace test_utils {
+
+  //! \brief get the required information from the environment variables GH_USER and GH_PASS
+  inline gh::auth get_auth() {
+
+    auto env_user = std::getenv("GH_USER");
+    auto env_pass = std::getenv("GH_PASS");
+
+    if(!env_user || !env_pass) {
+      std::cout << "This test needs the environment variables GH_USER and GH_PASS to be defined and holding valid github.com credentials\nExiting" << std::endl;
+      std::exit(1);
+    }
+
+    return gh::auth{ env_user, env_pass };
+  }
+}


### PR DESCRIPTION
As discussed recently we need pagination support on a couple of GH APIs which have been added now.

APIs that have first level API pagination (like branches / issues etc) are doing the link following automatically. 

Small bugfix: it turns out that the issue.body property is actually nullable (was causing crashes in the new test), so the property was changed to be an `std::optional`.